### PR TITLE
Update Client.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+/vendor
+composer.lock
 .idea

--- a/AmazonAdvertisingApi/Client.php
+++ b/AmazonAdvertisingApi/Client.php
@@ -256,7 +256,11 @@ class Client
 
         $request = new CurlRequest();
         $this->endpoint = trim($this->endpoint, "/");
+        if (str_starts_with($interface, 'reporting/reports') && (str_ends_with($this->endpoint, '/' . $this->apiVersion))) {
+            $this->endpoint = substr($this->endpoint, 0, strlen($this->endpoint) - strlen('/' . $this->apiVersion));
+        }
         $url = "{$this->endpoint}/{$interface}";
+
         $this->requestId = null;
 
         switch (strtolower($method)) {
@@ -286,6 +290,7 @@ class Client
         $request->setOption(CURLOPT_HTTPHEADER, $this->headers);
         $request->setOption(CURLOPT_USERAGENT, $this->userAgent);
         $request->setOption(CURLOPT_CUSTOMREQUEST, strtoupper($method));
+
         return $this->executeRequest($request);
     }
 

--- a/AmazonAdvertisingApi/Client.php
+++ b/AmazonAdvertisingApi/Client.php
@@ -429,12 +429,12 @@ class Client
      */
     protected function getCampaignTypeFromData(?array $data): string
     {
-        if (empty($data)) {
-            return static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS;
-        }
-        $campaignType = is_array($data) && isset($data['campaignType'])
-            ? $data['campaignType']
-            : static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS;
+        $campaignType =
+            (empty($data))
+            ? static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS
+            : ((is_array($data) && isset($data['campaignType']))
+                ? $data['campaignType']
+                : static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS);
         if ($campaignType === static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS) {
             return 'sp';
         } elseif ($campaignType === static::CAMPAIGN_TYPE_SPONSORED_BRANDS) {

--- a/AmazonAdvertisingApi/Client.php
+++ b/AmazonAdvertisingApi/Client.php
@@ -134,8 +134,12 @@ class Client
         if (is_array($response_array) && array_key_exists("access_token", $response_array)) {
             $this->config["accessToken"] = $response_array["access_token"];
         } else {
-            $this->logAndThrow("Unable to refresh token. 'access_token' not found in response. " . print_r($response,
-                    true));
+            $this->logAndThrow(
+                "Unable to refresh token. 'access_token' not found in response. " . print_r(
+                    $response,
+                    true
+                )
+            );
         }
 
         return $response;
@@ -440,11 +444,11 @@ class Client
             : ((is_array($data) && isset($data['campaignType']))
                 ? $data['campaignType']
                 : static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS);
-        if ($campaignType === static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS) {
+        if (($campaignType === static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS) || ($campaignType === 'sp')) {
             return 'sp';
-        } elseif ($campaignType === static::CAMPAIGN_TYPE_SPONSORED_BRANDS) {
+        } elseif (($campaignType === static::CAMPAIGN_TYPE_SPONSORED_BRANDS) || ($campaignType === 'hsa')) {
             return 'hsa';
-        } elseif ($campaignType === static::CAMPAIGN_TYPE_SPONSORED_DISPLAY) {
+        } elseif (($campaignType === static::CAMPAIGN_TYPE_SPONSORED_DISPLAY) || ($campaignType === 'sd')) {
             return 'sd';
         } else {
             return 'sp';

--- a/AmazonAdvertisingApi/SponsoredProductsRequests.php
+++ b/AmazonAdvertisingApi/SponsoredProductsRequests.php
@@ -1088,7 +1088,10 @@ trait SponsoredProductsRequests
         if (!$type && $this->apiVersion == 'v2') {
             $this->logAndThrow("Unable to perform request. No type is set");
         }
-        return $this->operation($type . "{$recordType}/report", $data, "POST");
+
+        $data['name'] = $recordType . ' ' . $data['startDate'] . ':' . $data['endDate'];
+
+        return $this->operation('reporting/reports', $data, "POST", ['Content-Type' => 'application/vnd.createasyncreportrequest.v3+json']);
     }
 
     /**
@@ -1119,7 +1122,7 @@ trait SponsoredProductsRequests
      */
     public function getReport($reportId)
     {
-        $req = $this->operation("reports/{$reportId}");
+        $req = $this->operation('reporting/reports/' . $reportId);
         if ($req["success"]) {
             $json = json_decode($req["response"], true);
             if ($json["status"] == "SUCCESS") {


### PR DESCRIPTION
Original empty $data process would return static constant, instead of using the constant as a default and continuing the translation.
This properly sets $campaignType to static::CAMPAIGN_TYPE_SPONSORED_PRODUCTS if $data is empty, and continues the process which translates to 'sp'